### PR TITLE
Build Docker image as part of CI + Pin BehaviorTree.CPP to 4.0.2

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,25 @@
+name: build_docker
+
+on:
+  # Run action on certain pull request events
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+  # Nightly job on default (main) branch
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  # Build docker images
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+            file: docker/Dockerfile
+            push: false

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -1,5 +1,21 @@
 repositories:
 
+  # TurtleBot3 Repos
+  # TODO: Switch back to apt installs once this PR is in the binary release:
+  # https://github.com/ROBOTIS-GIT/turtlebot3/pull/916
+  turtlebot3:
+    type: git
+    url: https://github.com/ROBOTIS-GIT/turtlebot3.git
+    version: humble-devel
+  turtlebot3_msgs:
+    type: git
+    url: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
+    version: humble-devel
+  turtlebot3_simulations:
+    type: git
+    url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
+    version: humble-devel
+
   # py_trees and related packages.
   py_trees:
     type: git

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -1,21 +1,5 @@
 repositories:
 
-  # TurtleBot3 Repos
-  # TODO: Switch back to apt installs once this PR is in the binary release:
-  # https://github.com/ROBOTIS-GIT/turtlebot3/pull/916
-  turtlebot3:
-    type: git
-    url: https://github.com/ROBOTIS-GIT/turtlebot3.git
-    version: humble-devel
-  turtlebot3_msgs:
-    type: git
-    url: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
-    version: humble-devel
-  turtlebot3_simulations:
-    type: git
-    url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
-    version: humble-devel
-
   # py_trees and related packages.
   py_trees:
     type: git

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -44,7 +44,7 @@ repositories:
   behaviortree_cpp:
     type: git
     url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-    version: master
+    version: 4.1.1
   groot:
     type: git
     url: https://github.com/BehaviorTree/Groot.git

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -44,7 +44,7 @@ repositories:
   behaviortree_cpp:
     type: git
     url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-    version: 4.1.1
+    version: 4.0.2
   groot:
     type: git
     url: https://github.com/BehaviorTree/Groot.git

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,6 +69,7 @@ WORKDIR /overlay_ws
 COPY ./tb3_autonomy/ ./src/tb3_autonomy/
 COPY ./tb3_worlds/ ./src/tb3_worlds/
 RUN source /turtlebot3_ws/install/setup.bash \
+ && rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y \
  && colcon build --symlink-install
 
 # Set up the entrypoint

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,9 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  ros-humble-gazebo-ros \
  ros-humble-navigation2 \
  ros-humble-nav2-bringup \
- ros-humble-rmw-cyclonedds-cpp \
- ros-humble-turtlebot3 \
- ros-humble-turtlebot3-gazebo
+ ros-humble-rmw-cyclonedds-cpp
 
 # Use Cyclone DDS as middleware
 ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  ros-humble-gazebo-ros \
  ros-humble-navigation2 \
  ros-humble-nav2-bringup \
- ros-humble-rmw-cyclonedds-cpp
+ ros-humble-rmw-cyclonedds-cpp \
+ ros-humble-turtlebot3 \
+ ros-humble-turtlebot3-gazebo
 
 # Use Cyclone DDS as middleware
 ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
@@ -44,8 +46,7 @@ RUN vcs import < dependencies.repos
 WORKDIR /turtlebot3_ws
 RUN source /opt/ros/humble/setup.bash \
  && apt-get update -y \
- && rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y
-RUN source /opt/ros/humble/setup.bash \
+ && rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y \
  && colcon build --symlink-install
 
 # Remove display warnings

--- a/tb3_autonomy/src/autonomy_node.cpp
+++ b/tb3_autonomy/src/autonomy_node.cpp
@@ -25,19 +25,6 @@ const std::string default_location_file =
     tb3_worlds_share_dir + "/maps/sim_house_locations.yaml";
 
 
-// Helper to register behaviors that accept a pointer to a ROS node.
-template <class NodeBehaviorT> 
-void registerRosNodeType(BT::BehaviorTreeFactory& factory,
-                         const std::string& registration_ID,
-                         rclcpp::Node::SharedPtr node_ptr) {
-    BT::NodeBuilder builder = [=](const std::string& name,
-                                  const BT::NodeConfig& config) {
-        return std::make_unique<NodeBehaviorT>(name, config, node_ptr);
-    };
-    factory.registerBuilder<NodeBehaviorT>(registration_ID, builder);
-}
-
-
 class AutonomyNode : public rclcpp::Node {
     public:
         AutonomyNode() : Node("autonomy_node") {
@@ -81,10 +68,8 @@ class AutonomyNode : public rclcpp::Node {
             BT::BehaviorTreeFactory factory;
             factory.registerNodeType<SetLocations>("SetLocations");
             factory.registerNodeType<GetLocationFromQueue>("GetLocationFromQueue");
-            registerRosNodeType<GoToPose>(
-                factory, "GoToPose", shared_from_this());
-            registerRosNodeType<LookForObject>(
-                factory, "LookForObject", shared_from_this());
+            factory.registerNodeType<GoToPose>(factory, "GoToPose", shared_from_this());
+            factory.registerNodeType<LookForObject>(factory, "LookForObject", shared_from_this());
             
             const std::string tree_file = (enable_vision_ ? std::string{} : "nav_") + "tree_" + tree_type_ + ".xml";
             auto blackboard = BT::Blackboard::create();

--- a/tb3_autonomy/src/autonomy_node.cpp
+++ b/tb3_autonomy/src/autonomy_node.cpp
@@ -68,8 +68,8 @@ class AutonomyNode : public rclcpp::Node {
             BT::BehaviorTreeFactory factory;
             factory.registerNodeType<SetLocations>("SetLocations");
             factory.registerNodeType<GetLocationFromQueue>("GetLocationFromQueue");
-            factory.registerNodeType<GoToPose>(factory, "GoToPose", shared_from_this());
-            factory.registerNodeType<LookForObject>(factory, "LookForObject", shared_from_this());
+            factory.registerNodeType<GoToPose>("GoToPose", shared_from_this());
+            factory.registerNodeType<LookForObject>("LookForObject", shared_from_this());
             
             const std::string tree_file = (enable_vision_ ? std::string{} : "nav_") + "tree_" + tree_type_ + ".xml";
             auto blackboard = BT::Blackboard::create();

--- a/tb3_worlds/package.xml
+++ b/tb3_worlds/package.xml
@@ -13,6 +13,7 @@
   <depend>gazebo_msgs</depend>
   <depend>gazebo_ros</depend>
   <depend>geometry_msgs</depend>
+  <depend>turtlebot3</depend>
   <depend>turtlebot3_gazebo</depend>
 
   <export>


### PR DESCRIPTION
This PR sets up a basic GitHub action to build the Docker container for this repo.

It also pins the BT.CPP version to 4.0.2 which is the last version that cleanly supports Groot 1.

Closes #24