### PR TITLE
Restore host user in dev container workflow

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -58,6 +58,10 @@ services:
       context: .
       dockerfile: docker/Dockerfile
       target: dev
+      args:
+        - UID=${UID:-1000}
+        - GID=${UID:-1000}
+        - USERNAME=${USERNAME:-devuser}
     volumes:
       # Mount the source code
       - ./tb_autonomy:/overlay_ws/src/tb_autonomy:rw
@@ -66,6 +70,7 @@ services:
       - ./.colcon/build/:/overlay_ws/build/:rw
       - ./.colcon/install/:/overlay_ws/install/:rw
       - ./.colcon/log/:/overlay_ws/log/:rw
+    user: ${USERNAME:-devuser}
     command: sleep infinity
 
   # Demo simulation world

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,11 +74,38 @@ ENTRYPOINT [ "/entrypoint.sh" ]
 #####################
 FROM overlay AS dev
 
+# Dev container arguments
+ARG USERNAME=devuser
+ARG UID=1000
+ARG GID=${UID}
+
 # Install extra tools for development
 RUN apt-get update && apt-get install -y --no-install-recommends \
  gdb gdbserver nano
 
+# In Ubuntu 24.04, there is already a user named "ubuntu" with UID 1000.
+# Delete this in the (common) event that the user on the host also has this UID.
+RUN touch /var/mail/ubuntu \
+    && chown ubuntu /var/mail/ubuntu \
+    && userdel -r ubuntu
+
+# Create new user and home directory
+RUN groupadd --gid $GID $USERNAME \
+ && useradd --uid ${GID} --gid ${UID} --create-home ${USERNAME} \
+ && echo ${USERNAME} ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/${USERNAME} \
+ && chmod 0440 /etc/sudoers.d/${USERNAME} \
+ && mkdir -p /home/${USERNAME} \
+ && chown -R ${UID}:${GID} /home/${USERNAME}
+
+# Set the ownership of the overlay workspace to the new user
+RUN chown -R ${UID}:${GID} /overlay_ws/
+
+# Move Groot2 to new user's home directory and ensure it can be run
+RUN groupadd fuse \
+ && usermod -aG fuse ${USERNAME}
+RUN mv /root/Groot2.AppImage /home/${USERNAME} \ 
+ && chown ${UID}:${GID} /home/${USERNAME}/Groot2.AppImage
+
 # Set up the entrypoint, including it in the .bashrc for interactive shells
-COPY ./docker/entrypoint.sh /
-ENTRYPOINT [ "/entrypoint.sh" ]
-RUN echo "source /entrypoint.sh" >> ~/.bashrc
+USER ${USERNAME}
+RUN echo "source /entrypoint.sh" >> /home/${USERNAME}/.bashrc


### PR DESCRIPTION
In Ubuntu 24.04, there is a cool surprise in that the standard image contains a user named `ubuntu` with UID 1000:
https://askubuntu.com/questions/1513927/ubuntu-24-04-docker-images-now-includes-user-ubuntu-with-uid-gid-1000

This conflicted with the existing dev container workflow, so I had temporarily taken out the creation of a user with the same UID/GID as the host. But no longer!