### PR TITLE
Build nav2 from source

### DIFF
--- a/dependencies.repos
+++ b/dependencies.repos
@@ -28,11 +28,9 @@ repositories:
     type: git
     url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
     version: devel
-  # NOTE: For now, using a personal fork to remove deprecation warnings:
-  # https://github.com/splintered-reality/py_trees_ros_viewer/pull/34
   py_trees_ros_viewer:
     type: git
-    url: https://github.com/sea-bass/py_trees_ros_viewer.git
+    url: https://github.com/splintered-reality/py_trees_ros_viewer.git
     version: devel
 
   # BehaviorTree.CPP for C++ based behavior trees.

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -1,4 +1,10 @@
 repositories:
+  # Nav2 repo (seems like the binaries are not working at the moment)
+  navigation2:
+    type: git
+    url: https://github.com/ros-navigation/navigation2.git
+    version: jazzy
+
   # Simulation and Nav2 support for TurtleBot robots
   nav2_minimal_turtlebot_simulation:
     type: git

--- a/tb_worlds/launch/tb_demo_world.launch.py
+++ b/tb_worlds/launch/tb_demo_world.launch.py
@@ -15,8 +15,6 @@ from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 
-from launch_ros.actions import Node
-
 
 def generate_launch_description():
     # Get the launch directory
@@ -122,7 +120,7 @@ def generate_launch_description():
         }.items(),
     )
 
-    bringup_cmd = IncludeLaunchDescription(
+    nav_bringup_cmd = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(nav2_bringup_dir, "launch", "bringup_launch.py")
         ),
@@ -158,7 +156,7 @@ def generate_launch_description():
     # Add the actions to launch all of the navigation nodes
     ld.add_action(sim_cmd)
     ld.add_action(rviz_cmd)
-    ld.add_action(bringup_cmd)
     ld.add_action(block_spawner_cmd)
+    ld.add_action(nav_bringup_cmd)
 
     return ld


### PR DESCRIPTION
Per https://github.com/sea-bass/turtlebot3_behavior_demos/issues/57, seems like something in the nav2 binaries is taking down this demo due to TF lookup errors, but the tip of Jazzy (release 1.3.5) from source seems to work?