### PR TITLE
Remove BehaviorTree.CPP and PyTrees source builds

### DIFF
--- a/dependencies.repos
+++ b/dependencies.repos
@@ -4,25 +4,3 @@ repositories:
     type: git
     url: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation.git
     version: main
-
-  # py_trees and related packages for Python based behavior trees.
-  py_trees:
-    type: git
-    url: https://github.com/splintered-reality/py_trees.git
-    version: devel
-  py_trees_js:
-    type: git
-    url: https://github.com/splintered-reality/py_trees_js.git
-    version: devel
-  py_trees_ros:
-    type: git
-    url: https://github.com/splintered-reality/py_trees_ros.git
-    version: devel
-  py_trees_ros_interfaces:
-    type: git
-    url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
-    version: devel
-  py_trees_ros_viewer:
-    type: git
-    url: https://github.com/splintered-reality/py_trees_ros_viewer.git
-    version: devel

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -28,9 +28,3 @@ repositories:
     type: git
     url: https://github.com/sea-bass/py_trees_ros_viewer.git
     version: devel
-
-  # BehaviorTree.CPP for C++ based behavior trees.
-  behaviortree_cpp:
-    type: git
-    url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-    version: master

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -22,9 +22,7 @@ repositories:
     type: git
     url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
     version: devel
-  # NOTE: For now, using a personal fork to remove deprecation warnings:
-  # https://github.com/splintered-reality/py_trees_ros_viewer/pull/34
   py_trees_ros_viewer:
     type: git
-    url: https://github.com/sea-bass/py_trees_ros_viewer.git
+    url: https://github.com/splintered-reality/py_trees_ros_viewer.git
     version: devel

--- a/tb_autonomy/package.xml
+++ b/tb_autonomy/package.xml
@@ -16,6 +16,8 @@
   <depend>ament_index_cpp</depend>
   <depend>behaviortree_cpp</depend>
   <depend>nav2_msgs</depend>
+  <depend>py_trees_ros</depend>
+  <depend>py_trees_ros_viewer</depend>
   <depend>sensor_msgs</depend>
   <depend>tb_worlds</depend>
   <depend>tf2</depend>


### PR DESCRIPTION
Seems like mixing binaries of Nav2 and source build of BT.CPP is what makes the `bt_navigator` crash. 

This should fix the issue, just as using source builds of `main` for both libraries will fix it as well (though not guaranteed). So it's both faster to build and more stable to just rely on binaries here.

Since I've released PyTrees to Humble/Jazzy/Rolling in the recent past, I'll also remove those source dependencies while we're at it.

Closes #57 