### PR TITLE
Update Nav2 config file to not consider footprint in cost critic

### DIFF
--- a/tb_worlds/configs/nav2_params.yaml
+++ b/tb_worlds/configs/nav2_params.yaml
@@ -1,5 +1,5 @@
 # This file has been modified from
-# https://github.com/ros-navigation/navigation2/blob/9d60bc0a3ca4e201250254c866c4eedc1441ed4e/nav2_bringup/params/nav2_params.yaml
+# https://github.com/ros-navigation/navigation2/blob/3ee33f73a211f7e75c6f147644ec6ff275b94c88/nav2_bringup/params/nav2_params.yaml
 # Modification:
 #   - Set initial_pose for AMCL
 #   - Use stamped_cmd_vel
@@ -7,6 +7,7 @@
 /**:
   ros__parameters:
     enable_stamped_cmd_vel: true
+
 amcl:
   ros__parameters:
     alpha1: 0.2
@@ -118,6 +119,7 @@ controller_server:
       ax_max: 3.0
       ax_min: -3.0
       ay_max: 3.0
+      ay_min: -3.0
       az_max: 3.5
       vx_std: 0.2
       vy_std: 0.2
@@ -166,8 +168,9 @@ controller_server:
         enabled: true
         cost_power: 1
         cost_weight: 3.81
+        near_collision_cost: 253
         critical_cost: 300.0
-        consider_footprint: true
+        consider_footprint: false
         collision_cost: 1000000.0
         near_goal_distance: 1.0
         trajectory_point_step: 2
@@ -437,6 +440,13 @@ docking_server:
       k_delta: 2.0
       v_linear_min: 0.15
       v_linear_max: 0.15
+      use_collision_detection: true
+      costmap_topic: "local_costmap/costmap_raw"
+      footprint_topic: "local_costmap/published_footprint"
+      transform_tolerance: 0.1
+      projection_time: 5.0
+      simulation_step: 0.1
+      dock_collision_threshold: 0.3
 
 loopback_simulator:
   ros__parameters:
@@ -445,3 +455,9 @@ loopback_simulator:
     map_frame_id: "map"
     scan_frame_id: "base_scan"  # tb4_loopback_simulator.launch.py remaps to 'rplidar_link'
     update_duration: 0.02
+    scan_range_min: 0.05
+    scan_range_max: 30.0
+    scan_angle_min: -3.1415
+    scan_angle_max: 3.1415
+    scan_angle_increment: 0.02617
+    scan_use_inf: true


### PR DESCRIPTION
This PR updates the latest Nav2 parameters YAML file to be based off the latest Jazzy version, to fix a segfault that cropped up.

Closes #69